### PR TITLE
refactor: switch to neg_binomial_2_log for numerical stability

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,4 @@
 ^PROJECT_OVERVIEW\.md$
 ^inst/stan/vr_reporting_model\.rds$
 ^\.Rhistory$
+^.gemini$

--- a/.gemini/tasks/log.md
+++ b/.gemini/tasks/log.md
@@ -1,0 +1,24 @@
+Please read issue #6 using `gh`.
+We are going to do the work described there.
+
+**Before starting:**
+- Think hard to brainstorm clarifying questions
+- If you have any such questions, STOP and ask them
+- Once everything is clear, pull main and create a new feature branch 6-...
+
+**During implementation:**
+- Don't get creative with the implementation - copy code directly from the issue as a starting point
+- Ensure that you use the relevant sub-agents and skills
+- Feel free to refine code as needed, but STOP if you start deviating from the issue significantly so we can discuss
+- Continue until the issue is done and all tests pass
+
+**Before creating PR:**
+- Ensure all tests pass
+- Review your work with @clean-code-reviewer, do not deviate from the issue if it suggests wider changes, just note them in the pr.
+- Verify the implementation matches all requirements from the issue
+
+**When creating the PR:**
+- Include "Closes #6" in the PR description to link the issue
+- Provide clear summary of changes and design decisions
+- Do NOT manually close the issue - GitHub will auto-close it when the PR merges
+- Leave the issue open for tracking until the PR is reviewed and merged

--- a/inst/stan/data/data_vr.stan
+++ b/inst/stan/data/data_vr.stan
@@ -1,4 +1,4 @@
-  int<lower=1> N;                      // number of observed cells
+int<lower=1> N;                      // number of observed cells
   int<lower=1> R;
   int<lower=1> T;
   int<lower=1> A;

--- a/inst/stan/data/tdata_vr.stan
+++ b/inst/stan/data/tdata_vr.stan
@@ -1,0 +1,1 @@
+  vector[N] log_exposure = log(exposure);

--- a/inst/stan/model/likelihood_vr_nb2.stan
+++ b/inst/stan/model/likelihood_vr_nb2.stan
@@ -32,7 +32,7 @@
         logit_rho += - delta_age[age[i]] * post[time[i]];
       }
 
-      real mu = exposure[i] * exp(log_lambda) * inv_logit(logit_rho);
-      y[i] ~ neg_binomial_2(mu, phi[g]);
+      real log_mu = log_exposure[i] + log_lambda + log_inv_logit(logit_rho);
+      y[i] ~ neg_binomial_2_log(log_mu, phi[g]);
     }
   }

--- a/inst/stan/model/likelihood_vr_nb2_rho1_pre.stan
+++ b/inst/stan/model/likelihood_vr_nb2_rho1_pre.stan
@@ -31,14 +31,14 @@
         logit_rho += - delta_age[age[i]] * post[time[i]];
       }
 
-      real mu;
+      real log_mu;
       if (post[time[i]] == 0) {
-        // Pre-conflict reporting fixed to 1
-        mu = exposure[i] * exp(log_lambda);
+        // Pre-conflict reporting fixed to 1 (log(1) = 0)
+        log_mu = log_exposure[i] + log_lambda;
       } else {
-        mu = exposure[i] * exp(log_lambda) * inv_logit(logit_rho);
+        log_mu = log_exposure[i] + log_lambda + log_inv_logit(logit_rho);
       }
 
-      y[i] ~ neg_binomial_2(mu, phi[g]);
+      y[i] ~ neg_binomial_2_log(log_mu, phi[g]);
     }
   }

--- a/inst/stan/vr_reporting_model.stan
+++ b/inst/stan/vr_reporting_model.stan
@@ -13,6 +13,10 @@ data {
 #include "data/data_vr.stan"
 }
 
+transformed data {
+#include "data/tdata_vr.stan"
+}
+
 parameters {
 #include "parameters/parameters_vr.stan"
 }

--- a/inst/stan/vr_reporting_model_nogq.stan
+++ b/inst/stan/vr_reporting_model_nogq.stan
@@ -8,6 +8,10 @@ data {
 #include "data/data_vr.stan"
 }
 
+transformed data {
+#include "data/tdata_vr.stan"
+}
+
 parameters {
 #include "parameters/parameters_vr.stan"
 }

--- a/inst/stan/vr_reporting_model_rho1_pre.stan
+++ b/inst/stan/vr_reporting_model_rho1_pre.stan
@@ -14,6 +14,10 @@ data {
 #include "data/data_vr.stan"
 }
 
+transformed data {
+#include "data/tdata_vr.stan"
+}
+
 parameters {
 #include "parameters/parameters_vr_rho1_pre.stan"
 }

--- a/inst/stan/vr_reporting_model_rho1_pre_nogq.stan
+++ b/inst/stan/vr_reporting_model_rho1_pre_nogq.stan
@@ -8,6 +8,10 @@ data {
 #include "data/data_vr.stan"
 }
 
+transformed data {
+#include "data/tdata_vr.stan"
+}
+
 parameters {
 #include "parameters/parameters_vr_rho1_pre.stan"
 }


### PR DESCRIPTION
- Updated Stan likelihood blocks to use neg_binomial_2_log and log_mu
- Centralized log_exposure calculation in transformed data for performance
- Maintained mu_rep on natural scale in generated quantities for compatibility
- Updated .Rbuildignore to ignore .gemini directory

Closes #6